### PR TITLE
chore: fix docs link

### DIFF
--- a/src/components/nav/index.tsx
+++ b/src/components/nav/index.tsx
@@ -31,7 +31,7 @@ const LinkNav: React.FC = () => {
 			tooltip: 'Twitter',
 		},
 		{
-			link: 'http://localhost:8080/get-started/',
+			link: 'http://docs.huff.sh/get-started/',
 			icon: 'book',
 			tooltip: 'Documentation & Specification',
 		},


### PR DESCRIPTION
## Overview

Changes the docs link from a base url of `localhost:8080` to `docs.huff.sh`