### PR TITLE
[fix] add correct link for huff docs

### DIFF
--- a/src/components/nav/index.tsx
+++ b/src/components/nav/index.tsx
@@ -31,7 +31,7 @@ const LinkNav: React.FC = () => {
 			tooltip: 'Twitter',
 		},
 		{
-			link: 'http://localhost:8080/get-started/overview/',
+			link: 'https://docs.huff.sh/get-started/',
 			icon: 'book',
 			tooltip: 'Documentation & Specification',
 		},


### PR DESCRIPTION
**Overview**

This PR provides the fix for the correct link related to the Huff Docs.

